### PR TITLE
feat: add npm executor and npm executor execution context view

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,9 +5,15 @@ plugins {
 group = "org.openrewrite.recipe"
 description = "Rewrite Node.js."
 
+val rewriteVersion = if(project.hasProperty("releasing")) {
+    "latest.release"
+} else {
+    "latest.integration"
+}
+
 dependencies {
-    implementation("org.openrewrite:rewrite-json:8.19.0")
-    implementation("org.openrewrite:rewrite-core:8.19.0")
+    implementation("org.openrewrite:rewrite-json:${rewriteVersion}")
+    implementation("org.openrewrite:rewrite-core:${rewriteVersion}")
 }
 
 configure<PublishingExtension> {

--- a/src/main/java/org/openrewrite/nodejs/NpmExecutor.java
+++ b/src/main/java/org/openrewrite/nodejs/NpmExecutor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.nodejs;
+
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.With;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.shell.exec.ShellExecutor;
+
+import java.nio.file.Path;
+
+@AllArgsConstructor
+@NoArgsConstructor
+public class NpmExecutor implements ShellExecutor {
+    @With
+    @Nullable
+    // Path to the directory containing the npm configuration files
+    private Path configurationDirectory;
+}

--- a/src/main/java/org/openrewrite/nodejs/NpmExecutorExecutionContextView.java
+++ b/src/main/java/org/openrewrite/nodejs/NpmExecutorExecutionContextView.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.nodejs;
+
+import org.openrewrite.DelegatingExecutionContext;
+import org.openrewrite.ExecutionContext;
+
+@SuppressWarnings("unused")
+public class NpmExecutorExecutionContextView extends DelegatingExecutionContext {
+    private static final String NPM_EXECUTOR = "org.openrewrite.nodejs.npmExecutor";
+
+    public NpmExecutorExecutionContextView(ExecutionContext delegate) {
+        super(delegate);
+    }
+
+    public static NpmExecutorExecutionContextView view(ExecutionContext ctx) {
+        if (ctx instanceof NpmExecutorExecutionContextView) {
+            return (NpmExecutorExecutionContextView) ctx;
+        }
+        return new NpmExecutorExecutionContextView(ctx);
+    }
+
+    public NpmExecutorExecutionContextView setNpmExecutor(NpmExecutor npmExecutor) {
+        putMessage(NPM_EXECUTOR, npmExecutor);
+        return this;
+    }
+
+    public NpmExecutor getNpmExecutor() {
+        return getMessage(NPM_EXECUTOR, new NpmExecutor());
+    }
+}


### PR DESCRIPTION
## What's changed?
Adding an npm executor and npm executor execution context view to allow for customization of npm environment when running a recipe. 
- Requires https://github.com/openrewrite/rewrite/pull/4326/ 

## What's your motivation?
There is a need to allow for customization to npm environment so npm registry settings can be overwritten to allow for installs in isolated environments where public npm registries are not accessible.

## Anyone you would like to review specifically?
@timtebeek @kmccarp 

## Any additional context
- Related to: https://github.com/moderneinc/customer-requests/issues/402

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
