### PR TITLE
Add CVE markers to vulnerable dependencies

### DIFF
--- a/src/main/java/org/openrewrite/nodejs/DependencyVulnerabilityCheck.java
+++ b/src/main/java/org/openrewrite/nodejs/DependencyVulnerabilityCheck.java
@@ -21,8 +21,15 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.*;
+import org.openrewrite.internal.StringUtils;
+import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.json.JsonIsoVisitor;
+import org.openrewrite.json.JsonPathMatcher;
 import org.openrewrite.json.tree.Json;
+import org.openrewrite.marker.SearchResult;
+import org.openrewrite.nodejs.internal.StaticVersionComparator;
+import org.openrewrite.nodejs.internal.Version;
+import org.openrewrite.nodejs.internal.VersionParser;
 import org.openrewrite.nodejs.search.IsPackageJson;
 import org.openrewrite.nodejs.search.IsPackageLockJson;
 import org.openrewrite.nodejs.table.VulnerabilityReport;
@@ -32,12 +39,21 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
 
-import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
 public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulnerabilityCheck.Accumulator> {
+    transient VersionParser versionParser = new VersionParser();
     transient VulnerabilityReport report = new VulnerabilityReport(this);
+
+    @Option(displayName = "Add search markers",
+            description = "Report each vulnerability as search result markers. " +
+                          "When enabled you can see which dependencies are bringing in vulnerable transitives in the diff view. " +
+                          "By default these markers are omitted, making it easier to see version upgrades within the diff.",
+            required = false)
+    @Nullable
+    Boolean addMarkers;
 
     @Override
     public String getDisplayName() {
@@ -110,7 +126,7 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
                     for (Vulnerability v : acc.getDb().getOrDefault(dependency.getName(), Collections.emptyList())) {
                         String resolvedVersion = dependency.getResolved() == null ? null : dependency.getResolved().getVersion();
                         acc.getVulnerabilities()
-                                .computeIfAbsent(new Accumulator.NameVersion(dependency.getName(), resolvedVersion), nv -> new HashSet<>())
+                                .computeIfAbsent(new Accumulator.NameVersion(dependency.getName(), resolvedVersion), nv -> new LinkedHashSet<>())
                                 .add(v);
                     }
                 }
@@ -134,6 +150,7 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
                         fixWithPatchVersionUpdateOnly,
                         vuln.getSummary(),
                         vuln.getSeverity().toString(),
+                        0,
                         vuln.getCwes()
                 ));
             }
@@ -143,26 +160,56 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor(Accumulator acc) {
+        JsonPathMatcher dependency = new JsonPathMatcher("$.dependencies");
+        JsonPathMatcher devDependencies = new JsonPathMatcher("$.devDependencies");
         return Preconditions.check(new IsPackageJson<>(), new JsonIsoVisitor<ExecutionContext>() {
             @Override
             public Json.Document visitDocument(Json.Document document, ExecutionContext ctx) {
                 Json.Document d = super.visitDocument(document, ctx);
-                Map<Accumulator.NameVersion, Set<Vulnerability>> vulnerabilities = acc.getVulnerabilities();
-                Set<Map.Entry<Accumulator.NameVersion, Set<Vulnerability>>> entries = vulnerabilities.entrySet();
-                for (Map.Entry<Accumulator.NameVersion, Set<Vulnerability>> entry : entries) {
-                    Set<Vulnerability> vs = entry.getValue();
-                    for (Vulnerability vulnerability : vs) {
+                for (Map.Entry<Accumulator.NameVersion, Set<Vulnerability>> entry : acc.getVulnerabilities().entrySet()) {
+                    for (Vulnerability v : entry.getValue()) {
                         boolean fixWithPatchVersionUpdateOnly = new LatestPatch(null)
-                                .isValid(entry.getKey().getVersion(), vulnerability.getFixedVersion());
+                                .isValid(entry.getKey().getVersion(), v.getFixedVersion());
                         if (fixWithPatchVersionUpdateOnly) {
-                            d = (Json.Document) new UpgradeDependencyVersion(
-                                    vulnerability.getPackageName(),
-                                    '^' + vulnerability.getFixedVersion())
-                                    .getVisitor().visitNonNull(d, ctx, requireNonNull(getCursor().getParent()));
+                            d = (Json.Document) new UpgradeDependencyVersion(v.getPackageName(), '^' + v.getFixedVersion())
+                                    .getVisitor()
+                                    .visitNonNull(d, ctx, getCursor().getParentOrThrow());
                         }
                     }
                 }
                 return d;
+            }
+
+            @Override
+            public Json.Member visitMember(Json.Member member, ExecutionContext ctx) {
+                Json.Member m = super.visitMember(member, ctx);
+                if (!Boolean.TRUE.equals(addMarkers)) {
+                    return m;
+                }
+
+                Cursor maybeDependencies = getCursor().getParent(2);
+                if (maybeDependencies != null && (dependency.matches(maybeDependencies) || devDependencies.matches(maybeDependencies))) {
+                    String name = ((Json.Literal) member.getKey()).getValue().toString();
+                    for (Map.Entry<Accumulator.NameVersion, Set<Vulnerability>> entry : acc.getVulnerabilities().entrySet()) {
+                        Accumulator.NameVersion nameVersion = entry.getKey();
+                        if (nameVersion.getName().equals(name)) {
+                            Comparator<Version> vc = new StaticVersionComparator();
+                            Version resolvedVersion = versionParser.transform(nameVersion.getVersion());
+                            String CVEs = entry.getValue().stream()
+                                    .filter(v -> StringUtils.isBlank(v.getFixedVersion()) ||
+                                                 vc.compare(resolvedVersion, versionParser.transform(v.getFixedVersion())) < 0)
+                                    .map(v -> String.format("%s (%s severity%s) - %s",
+                                            v.getCve(),
+                                            v.getSeverity(),
+                                            StringUtils.isBlank(v.getFixedVersion()) ? "" : ", fixed in " + v.getFixedVersion(),
+                                            v.getSummary()))
+                                    .collect(joining("\n"));
+                            return SearchResult.found(m, "This dependency has the following vulnerabilities:\n" + CVEs);
+                        }
+                    }
+                }
+
+                return m;
             }
         });
     }

--- a/src/main/java/org/openrewrite/nodejs/internal/StaticVersionComparator.java
+++ b/src/main/java/org/openrewrite/nodejs/internal/StaticVersionComparator.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.nodejs.internal;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Allows for comparison of Version instances.
+ * Note that this comparator only considers the 'parts' of a version, and does not consider the part 'separators'.
+ * This means that it considers `1.1.1 == 1-1-1 == 1.1-1`, and should not be used in cases where this is important.
+ * One example where this comparator is inappropriate is if versions should be retained in a TreeMap/TreeSet.
+ * <br/>
+ * Copied from org.openrewrite.java.dependencies.internal.StaticVersionComparator.
+ */
+public class StaticVersionComparator implements Comparator<Version> {
+    static final Map<String, Integer> SPECIAL_MEANINGS = new HashMap<>();
+
+    static {
+        SPECIAL_MEANINGS.put("dev", -1);
+        SPECIAL_MEANINGS.put("rc", 1);
+        SPECIAL_MEANINGS.put("snapshot", 2);
+        SPECIAL_MEANINGS.put("final", 3);
+        SPECIAL_MEANINGS.put("ga", 4);
+        SPECIAL_MEANINGS.put("release", 5);
+        SPECIAL_MEANINGS.put("sp", 6);
+    }
+
+    /**
+     * Compares 2 versions. Algorithm is inspired by PHP version_compare one.
+     */
+    @Override
+    public int compare(Version version1, Version version2) {
+        if (version1.equals(version2)) {
+            return 0;
+        }
+
+        String[] parts1 = version1.getParts();
+        String[] parts2 = version2.getParts();
+        Long[] numericParts1 = version1.getNumericParts();
+        Long[] numericParts2 = version2.getNumericParts();
+
+        int i = 0;
+        for (; i < parts1.length && i < parts2.length; i++) {
+            String part1 = parts1[i];
+            String part2 = parts2[i];
+
+            Long numericPart1 = numericParts1[i];
+            Long numericPart2 = numericParts2[i];
+
+            boolean is1Number = numericPart1 != null;
+            boolean is2Number = numericPart2 != null;
+
+            if (part1.equals(part2)) {
+                continue;
+            }
+            if (is1Number && !is2Number) {
+                return 1;
+            }
+            if (is2Number && !is1Number) {
+                return -1;
+            }
+            if (is1Number && is2Number) {
+                int result = numericPart1.compareTo(numericPart2);
+                if (result == 0) {
+                    continue;
+                }
+                return result;
+            }
+            // both are strings, we compare them taking into account special meaning
+            Integer sm1 = SPECIAL_MEANINGS.get(part1.toLowerCase(Locale.US));
+            Integer sm2 = SPECIAL_MEANINGS.get(part2.toLowerCase(Locale.US));
+            if (sm1 != null) {
+                sm2 = sm2 == null ? 0 : sm2;
+                return sm1 - sm2;
+            }
+            if (sm2 != null) {
+                return -sm2;
+            }
+            return part1.compareTo(part2);
+        }
+        if (i < parts1.length) {
+            return numericParts1[i] == null ? -1 : 1;
+        }
+        if (i < parts2.length) {
+            return numericParts2[i] == null ? 1 : -1;
+        }
+
+        return 0;
+    }
+}

--- a/src/main/java/org/openrewrite/nodejs/internal/Version.java
+++ b/src/main/java/org/openrewrite/nodejs/internal/Version.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.nodejs.internal;
+
+public interface Version {
+    /**
+     * Returns the original {@link String} representation of the version.
+     */
+    String getSource();
+
+    /**
+     * Returns all the parts of this version. e.g. 1.2.3 returns [1,2,3] or 1.2-beta4 returns [1,2,beta,4].
+     */
+    String[] getParts();
+
+    /**
+     * Returns all the numeric parts of this version as {@link Long}, with nulls in non-numeric positions. eg. 1.2.3 returns [1,2,3] or 1.2-beta4 returns [1,2,null,4].
+     */
+    Long[] getNumericParts();
+}

--- a/src/main/java/org/openrewrite/nodejs/internal/VersionParser.java
+++ b/src/main/java/org/openrewrite/nodejs/internal/VersionParser.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.nodejs.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Copied from org.openrewrite.java.dependencies.internal.VersionParser.
+ */
+public class VersionParser {
+    private final Map<String, Version> cache = new ConcurrentHashMap<>();
+
+    public VersionParser() {
+    }
+
+    public Version transform(String original) {
+        return cache.computeIfAbsent(original, this::parse);
+    }
+
+    private Version parse(String original) {
+        List<String> parts = new ArrayList<>();
+        boolean digit = false;
+        int startPart = 0;
+        int pos = 0;
+        int endBaseStr = 0;
+        for (; pos < original.length(); pos++) {
+            char ch = original.charAt(pos);
+            if (ch == '.' || ch == '_' || ch == '-' || ch == '+') {
+                parts.add(original.substring(startPart, pos));
+                startPart = pos + 1;
+                digit = false;
+                if (ch != '.' && endBaseStr == 0) {
+                    endBaseStr = pos;
+                }
+            } else if (ch >= '0' && ch <= '9') {
+                if (!digit && pos > startPart) {
+                    if (endBaseStr == 0) {
+                        endBaseStr = pos;
+                    }
+                    parts.add(original.substring(startPart, pos));
+                    startPart = pos;
+                }
+                digit = true;
+            } else {
+                if (digit) {
+                    if (endBaseStr == 0) {
+                        endBaseStr = pos;
+                    }
+                    parts.add(original.substring(startPart, pos));
+                    startPart = pos;
+                }
+                digit = false;
+            }
+        }
+        if (pos > startPart) {
+            parts.add(original.substring(startPart, pos));
+        }
+        return new DefaultVersion(original, parts);
+    }
+
+    private static class DefaultVersion implements Version {
+        private final String source;
+        private final String[] parts;
+        private final Long[] numericParts;
+
+        public DefaultVersion(String source, List<String> parts) {
+            this.source = source;
+            this.parts = parts.toArray(new String[0]);
+            this.numericParts = new Long[this.parts.length];
+            for (int i = 0; i < parts.size(); i++) {
+                try {
+                    this.numericParts[i] = Long.parseLong(this.parts[i]);
+                } catch (NumberFormatException ignored) {
+                }
+            }
+        }
+
+        @Override
+        public String toString() {
+            return source;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+            if (obj == null || obj.getClass() != getClass()) {
+                return false;
+            }
+            DefaultVersion other = (DefaultVersion) obj;
+            return source.equals(other.source);
+        }
+
+        @Override
+        public int hashCode() {
+            return source.hashCode();
+        }
+
+        @Override
+        public String[] getParts() {
+            return parts;
+        }
+
+        @Override
+        public Long[] getNumericParts() {
+            return numericParts;
+        }
+
+        @Override
+        public String getSource() {
+            return source;
+        }
+    }
+}

--- a/src/main/java/org/openrewrite/nodejs/table/VulnerabilityReport.java
+++ b/src/main/java/org/openrewrite/nodejs/table/VulnerabilityReport.java
@@ -63,6 +63,10 @@ public class VulnerabilityReport extends DataTable<VulnerabilityReport.Row> {
                 description = "The calculated base score.")
         String severity;
 
+        @Column(displayName = "Depth",
+                description = "Zero for direct dependencies.")
+        Integer depth;
+
         @Column(displayName = "CWEs",
                 description = "Common Weakness Enumeration (CWE) identifiers; semicolon separated.")
         String CWEs;

--- a/src/test/java/org/openrewrite/nodejs/DependencyVulnerabilityCheckTest.java
+++ b/src/test/java/org/openrewrite/nodejs/DependencyVulnerabilityCheckTest.java
@@ -28,7 +28,7 @@ class DependencyVulnerabilityCheckTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new DependencyVulnerabilityCheck());
+        spec.recipe(new DependencyVulnerabilityCheck(null));
     }
 
     @Test
@@ -40,14 +40,14 @@ class DependencyVulnerabilityCheckTest implements RewriteTest {
             assertThat(rows)
               .hasSize(5)
               .anySatisfy(row -> {
-                assertThat(row.getCve()).isEqualTo("CVE-2010-2273");
-                assertThat(row.getSummary()).isEqualTo("Cross-Site Scripting in dojo");
-                assertThat(row.getPackageName()).isEqualTo("dojo");
-                assertThat(row.getVersion()).isEqualTo("1.10.5");
-                assertThat(row.getFixedVersion()).isEqualTo("1.10.10");
-                assertThat(row.getSeverity()).isEqualTo("MODERATE");
-                assertThat(row.getCWEs()).isEqualTo("CWE-79");
-            })),
+                  assertThat(row.getCve()).isEqualTo("CVE-2010-2273");
+                  assertThat(row.getSummary()).isEqualTo("Cross-Site Scripting in dojo");
+                  assertThat(row.getPackageName()).isEqualTo("dojo");
+                  assertThat(row.getVersion()).isEqualTo("1.10.5");
+                  assertThat(row.getFixedVersion()).isEqualTo("1.10.10");
+                  assertThat(row.getSeverity()).isEqualTo("MODERATE");
+                  assertThat(row.getCWEs()).isEqualTo("CWE-79");
+              })),
           json(
             //language=json
             """
@@ -66,6 +66,68 @@ class DependencyVulnerabilityCheckTest implements RewriteTest {
                 "version": "1.0.0",
                 "dependencies": {
                   "dojo": "^1.10.10"
+                }
+              }
+              """,
+            spec -> spec.path("package.json")
+          ),
+          json(
+            //language=json
+            """
+              {
+                "name": "example",
+                "version": "1.0.0",
+                "lockfileVersion": 3,
+                "requires": true,
+                "packages": {
+                  "": {
+                    "name": "example",
+                    "version": "1.0.0",
+                    "dependencies": {
+                      "dojo": "^1.10.0"
+                    }
+                  },
+                  "node_modules/dojo": {
+                    "version": "1.10.5",
+                    "resolved": "https://something",
+                    "integrity": "c29tZXRoaW5n",
+                    "engines": {
+                      "node": ">=18"
+                    }
+                  }
+                }
+              }
+              """,
+            spec -> spec.path("package-lock.json")
+          )
+        );
+    }
+
+    @Test
+    void shouldAddMarkersIfConfigured() {
+        rewriteRun(
+          spec -> spec.recipe(new DependencyVulnerabilityCheck(true)),
+          json(
+            //language=json
+            """
+              {
+                "name": "example",
+                "version": "1.0.0",
+                "dependencies": {
+                  "dojo": "^1.10.0"
+                }
+              }
+              """,
+            //language=json
+            """
+              {
+                "name": "example",
+                "version": "1.0.0",
+                "dependencies": {
+                  /*~~(This dependency has the following vulnerabilities:
+              CVE-2010-2273 (MODERATE severity, fixed in 1.10.10) - Cross-Site Scripting in dojo
+              CVE-2020-5258 (HIGH severity, fixed in 1.11.10) - Prototype pollution in dojo
+              CVE-2021-23450 (HIGH severity) - Prototype Pollution in dojo)~~>*/"dojo": "^1.10.10"
                 }
               }
               """,


### PR DESCRIPTION
## What's changed?
Added copies of classes in rewrite-java-dependencies to statically compare versions, and if vulnerable, add the corresponding markers.

## What's your motivation?
Helps both to visualize the issues found, as well as troubleshoot the recipe when it's not making code changes.